### PR TITLE
Change semantics of `advance!` to avoid changing the cursor.

### DIFF
--- a/spec/ByteStream.ChunkedReader.Spec.savi
+++ b/spec/ByteStream.ChunkedReader.Spec.savi
@@ -24,8 +24,12 @@
     assert: stream.token_as_string == "hell"
 
     // Try to advance further and fail partway through,
-    // leaving the cursor pointing to the end of the stream.
+    // leaving the cursor position unchanged.
     assert error: stream.advance!(4)
+    assert: stream.bytes_ahead == 1
+
+    // Now advance to the end of the currently available bytes.
+    stream.advance_to_end
     assert: stream.bytes_ahead == 0
     assert: stream.bytes_ahead_of_marker == 5
     assert: stream.token_byte_size == 5
@@ -96,10 +100,10 @@
     // Rewind then try to advance the cursor past the end, raising an error.
     stream.rewind_to_marker
     assert error: stream.advance!(13)
-    assert: stream.bytes_ahead == 0
+    assert: stream.bytes_ahead == 12
     assert: stream.bytes_ahead_of_marker == 12
-    assert: stream.token_byte_size == 12
-    assert: stream.token_as_string == "loworldlings"
+    assert: stream.token_byte_size == 0
+    assert: stream.token_as_string == ""
 
     // Rewind then advance the cursor to the end exactly using advance_to_end.
     stream.rewind_to_marker

--- a/spec/ByteStream.Reader.Spec.savi
+++ b/spec/ByteStream.Reader.Spec.savi
@@ -45,16 +45,16 @@
     assert: stream.token_as_string == "hell"
 
     // Try to advance further and fail partway through,
-    // leaving the cursor pointing to the end of the stream.
+    // leaving the cursor position unchanged.
     assert error: stream.advance!(4)
-    assert: stream.bytes_ahead == 0
+    assert: stream.bytes_ahead == 1
     assert: stream.bytes_ahead_of_marker == 5
-    assert: stream.space_ahead == initial_space - 5
+    assert: stream.space_ahead == initial_space - 4
     assert: stream.space_ahead_of_marker == initial_space
-    assert: stream.bytes_behind == 5
+    assert: stream.bytes_behind == 4
     assert: stream.bytes_behind_marker == 0
-    assert: stream.token_byte_size == 5
-    assert: stream.token_as_string == "hello"
+    assert: stream.token_byte_size == 4
+    assert: stream.token_as_string == "hell"
 
     // Rewind the cursor back to the marker position at the start of the stream.
     stream.rewind_to_marker
@@ -151,14 +151,14 @@
     // Rewind then try to advance the cursor past the end, raising an error.
     stream.rewind_to_marker
     assert error: stream.advance!(13)
-    assert: stream.bytes_ahead == 0
+    assert: stream.bytes_ahead == 12
     assert: stream.bytes_ahead_of_marker == 12
-    assert: stream.space_ahead == initial_space - 15
+    assert: stream.space_ahead == initial_space - 3
     assert: stream.space_ahead_of_marker == initial_space - 3
-    assert: stream.bytes_behind == 15
+    assert: stream.bytes_behind == 3
     assert: stream.bytes_behind_marker == 3
-    assert: stream.token_byte_size == 12
-    assert: stream.token_as_string == "loworldlings"
+    assert: stream.token_byte_size == 0
+    assert: stream.token_as_string == ""
 
     // Rewind then advance the cursor to the end exactly using advance_to_end.
     stream.rewind_to_marker

--- a/src/ByteStream.ChunkedReader.savi
+++ b/src/ByteStream.ChunkedReader.savi
@@ -279,34 +279,24 @@
 
   :: Advance the cursor forward in the byte stream by N total bytes.
   :: Raises an error if there are not enough bytes to do so, leaving the cursor
-  :: pointing to the next future byte that will arrive in the byte stream.
+  :: position unchanged in that case.
   :fun ref advance!(n USize)
-    if (n >= @_bytes_ahead) (
-      too_many_n = n > @_bytes_ahead
+    error! if (n > @_bytes_ahead)
 
-      // If we know this count will take us to the end of the stream,
-      // we can skip the extra work of iterating over chunks and jump there.
-      @advance_to_end
-
-      // If the caller requested too many bytes, then we also raise an error
-      // to indicate that more advancement is still needed to reach the goal.
-      if too_many_n error!
-    |
-      // Iterate through each chunk, keeping track of how much of the
-      // goal number of bytes remain to be consumed in the advancement.
-      remaining_n = n
-      current_chunk_remaining_count = @_chunks[@_chunk_index]!.size - @_offset
-      while (remaining_n > current_chunk_remaining_count) (
-        remaining_n -= current_chunk_remaining_count
-        @_chunk_index += 1
-        @_offset = 0
-        @_bytes_ahead -= current_chunk_remaining_count
-        current_chunk_remaining_count = @_chunks[@_chunk_index]!.size
-      )
-      @_offset += remaining_n
-      @_bytes_ahead -= remaining_n
-      @
+    // Iterate through each chunk, keeping track of how much of the
+    // goal number of bytes remain to be consumed in the advancement.
+    remaining_n = n
+    current_chunk_remaining_count = @_chunks[@_chunk_index]!.size - @_offset
+    while (remaining_n > current_chunk_remaining_count) (
+      remaining_n -= current_chunk_remaining_count
+      @_chunk_index += 1
+      @_offset = 0
+      @_bytes_ahead -= current_chunk_remaining_count
+      current_chunk_remaining_count = @_chunks[@_chunk_index]!.size
     )
+    @_offset += remaining_n
+    @_bytes_ahead -= remaining_n
+    @
 
   :: Advance the cursor byte-by-byte for as long as the block yields True,
   :: stopping the cursor pointing at the byte for which it yielded False.

--- a/src/ByteStream.Reader.savi
+++ b/src/ByteStream.Reader.savi
@@ -248,11 +248,12 @@
 
   :: Advance the cursor forward in the byte stream by N total bytes.
   :: Raises an error if there are not enough bytes to do so, leaving the cursor
-  :: pointing to the next future byte that will arrive in the byte stream.
+  :: position unchanged in that case.
   :fun ref advance!(n USize)
-    @_offset += n
-    if (@_offset > @_data.size) (
-      @_offset = @_data.size
+    offset = @_offset +! n
+    if (offset <= @_data.size) (
+      @_offset = offset
+    |
       error!
     )
     @


### PR DESCRIPTION
The original semantics (leaving the cursor pointing to the end
of the stream after raising an error) weren't that useful in practice.
It's much more useful to leave the cursor unchanged in the case
that `advance!` fails to have enough `bytes_ahead` to move forward
by the requested amount, and raises an `error!`.

This is a breaking change in the semantics of an existing method,
but existing code using this method is not relying on those semantics,
so in practice it should not break existing code in known libraries.