### PR TITLE
Change `ByteStream.Reader` to keep backend methods segregated.

### DIFF
--- a/spec/ByteStream.Reader.Spec.savi
+++ b/spec/ByteStream.Reader.Spec.savi
@@ -8,8 +8,10 @@
     assert: ByteStream.Reader.new(0x2000).space_ahead == 0x2000
 
   :it "can accept chunks, advance, and read tokens"
-    stream = ByteStream.Reader.new
-    write_stream = ByteStream.Writer.to_reader(stream)
+    streams = ByteStream.Pair.new
+    stream = streams.read
+    write_stream = streams.write
+
     initial_space = stream.space_ahead
 
     assert: stream.bytes_ahead == 0
@@ -208,8 +210,9 @@
     assert: stream.token_as_string == ""
 
   :it "reserves at least a specified amount of space in front of the cursor"
-    stream = ByteStream.Reader.new
-    write_stream = ByteStream.Writer.to_reader(stream)
+    streams = ByteStream.Pair.new
+    stream = streams.read
+    write_stream = streams.write
 
     assert: stream.space_ahead == 0x4000
     assert: stream.reserve_bytes_ahead(0x8000).space_ahead == 0x8000
@@ -229,8 +232,10 @@
     assert: stream.reserve_bytes_ahead(0x8000).space_ahead == 0xFFFD
 
   :it "extracts an isolated token destructively from the stream"
-    stream = ByteStream.Reader.new
-    write_stream = ByteStream.Writer.to_reader(stream)
+    streams = ByteStream.Pair.new
+    stream = streams.read
+    write_stream = streams.write
+
     write_stream << b"hel"
     write_stream << b"lowo"
     write_stream << b"rld"
@@ -246,8 +251,10 @@
     assert: stream.bytes_behind_marker == 8
 
   :it "yields each byte of a token"
-    stream = ByteStream.Reader.new
-    write_stream = ByteStream.Writer.to_reader(stream)
+    streams = ByteStream.Pair.new
+    stream = streams.read
+    write_stream = streams.write
+
     write_stream << b"hel"
     write_stream << b"lowo"
     write_stream << b"rld"
@@ -271,8 +278,10 @@
     collected.clear
 
   :it "yields each byte of a token until the block returns True"
-    stream = ByteStream.Reader.new
-    write_stream = ByteStream.Writer.to_reader(stream)
+    streams = ByteStream.Pair.new
+    stream = streams.read
+    write_stream = streams.write
+
     write_stream << b"hel"
     write_stream << b"lowo"
     write_stream << b"rld"
@@ -294,8 +303,10 @@
     collected.clear
 
   :it "compares a token for equivalence to a given string"
-    stream = ByteStream.Reader.new
-    write_stream = ByteStream.Writer.to_reader(stream)
+    streams = ByteStream.Pair.new
+    stream = streams.read
+    write_stream = streams.write
+
     write_stream << b"hel"
     write_stream << b"lowo"
     write_stream << b"rld"
@@ -319,8 +330,10 @@
     assert: stream.is_token_equal_to("lloWor").is_false
 
   :it "compares an ASCII-lowercased token for equivalence to a given string"
-    stream = ByteStream.Reader.new
-    write_stream = ByteStream.Writer.to_reader(stream)
+    streams = ByteStream.Pair.new
+    stream = streams.read
+    write_stream = streams.write
+
     write_stream << b"HeL"
     write_stream << b"LoWo"
     write_stream << b"RlD"
@@ -344,8 +357,10 @@
     assert: stream.is_token_ascii_lowercase_equal_to("lloWor").is_false
 
   :it "parses a token as a positive integer in decimal notation"
-    stream = ByteStream.Reader.new
-    write_stream = ByteStream.Writer.to_reader(stream)
+    streams = ByteStream.Pair.new
+    stream = streams.read
+    write_stream = streams.write
+
     write_stream << b"192"
     write_stream << b"8374"
     write_stream << b"650"
@@ -369,8 +384,10 @@
     assert error: stream.token_as_positive_integer!
 
   :it "reads integers in native, big and little endianness at specific offsets"
-    stream = ByteStream.Reader.new
-    write_stream = ByteStream.Writer.to_reader(stream)
+    streams = ByteStream.Pair.new
+    stream = streams.read
+    write_stream = streams.write
+
     write_stream << b"garbage"
     write_stream << Bytes.from_array([0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01])
     assert no_error: write_stream.flush!

--- a/spec/ByteStream.Writer.Spec.savi
+++ b/spec/ByteStream.Writer.Spec.savi
@@ -3,8 +3,7 @@
   :const describes: "ByteStream.Writer"
 
   :it "writes chunks of bytes and individual bytes"
-    read = ByteStream.Reader.new
-    write = ByteStream.Writer.to_reader(read)
+    streams = ByteStream.Pair.new, read = streams.read, write = streams.write
 
     // Write some data.
     write << b"Hello"
@@ -21,8 +20,7 @@
     assert: read.extract_all == b"Hello, World!"
 
   :it "writes U16, U32, and U64 values in native byte order"
-    read = ByteStream.Reader.new
-    write = ByteStream.Writer.to_reader(read)
+    streams = ByteStream.Pair.new, read = streams.read, write = streams.write
 
     // Write some data.
     write.push_native_u16(0x0123)

--- a/src/ByteStream.Pair.savi
+++ b/src/ByteStream.Pair.savi
@@ -1,0 +1,13 @@
+
+:: Convenience constructor for a `ByteStream.Reader` and `ByteStream.Writer`
+:: pair, as commonly used in testing code that uses byte streams.
+:struct ByteStream.Pair
+  :let read ByteStream.Reader
+  :let write ByteStream.Writer
+
+  :new
+    read_backend = ByteStream.Reader.Private.new
+    @read = read_backend.public
+    @write = ByteStream.Writer.new(
+      ByteStream.Sink.ToReader.new(read_backend)
+    )

--- a/src/ByteStream.Reader.savi
+++ b/src/ByteStream.Reader.savi
@@ -37,6 +37,8 @@
   :new (space USize = 0x4000)
     @_data = Bytes.new(space)
 
+  :: DEPRECATED: Methods like this will soon only be in `ByteStream.Reader.Private`.
+  ::
   :: Reset this object back to an empty state so that it can be reused.
   :: All data held and all cursor and mark state will be dropped.
   ::
@@ -50,15 +52,8 @@
     @_lost_offset = 0
     @
 
-  :: Drop any bytes that have been passed by both the marker and cursor,
-  :: allowing buffers to be garbage collected even in the middle of a stream.
+  :: DEPRECATED: Methods like this will soon only be in `ByteStream.Reader.Private`.
   ::
-  :: If at the end of a stream it is more efficient to call clear instead.
-  // TODO: Implement the compact function
-  // :fun ref compact
-  //   // ...
-  //   @
-
   :: Receive some bytes from the given source, extending the end of the stream.
   :: Returns the number of bytes that were received, as reported by the source.
   :: Raises an error if the source has become permanently closed off.
@@ -112,6 +107,8 @@
   :: very start of the byte stream, including bytes no longer held in buffer.
   :fun bytes_behind_marker: @_mark_offset + @_lost_offset
 
+  :: DEPRECATED: Methods like this will soon only be in `ByteStream.Reader.Private`.
+  ::
   :: Ensure that the underlying byte buffer is ready to handle the given amount
   :: of bytes ahead of the current cursor position, without copying on receive.
   :: This includes both bytes already in the buffer and space for future bytes.
@@ -124,6 +121,8 @@
     @_data.reserve(actual_amount)
     @
 
+  :: DEPRECATED: Methods like this will soon only be in `ByteStream.Reader.Private`.
+  ::
   :: Reserve additional space in the underlying byte buffer, which forces a
   :: reallocation now, but sets a minimum number of bytes that the buffer
   :: can receive beyond the current size without forcing a reallocation.
@@ -342,18 +341,111 @@
   :fun ref peek_native_u64!(n USize = 0) U64
     @_data.read_native_u64!(@_offset +! n)
 
-  // DEPRECATED: use `take_byte!` or `peek_byte!` instead
+  :: DEPRECATED: use `take_byte!` or `peek_byte!` instead
   :fun read_byte!(offset USize) U8
     @_data.read_byte!(@_mark_offset +! offset)
 
-  // DEPRECATED: use `take_native_u16!` or `peek_native_u16!` instead
+  :: DEPRECATED: use `take_native_u16!` or `peek_native_u16!` instead
   :fun read_native_u16!(offset USize) U16
     @_data.read_native_u16!(@_mark_offset +! offset)
 
-  // DEPRECATED: use `take_native_u32!` or `peek_native_u32!` instead
+  :: DEPRECATED: use `take_native_u32!` or `peek_native_u32!` instead
   :fun read_native_u32!(offset USize) U32
     @_data.read_native_u32!(@_mark_offset +! offset)
 
-  // DEPRECATED: use `take_native_u64!` or `peek_native_u64!` instead
+  :: DEPRECATED: use `take_native_u64!` or `peek_native_u64!` instead
   :fun read_native_u64!(offset USize) U64
     @_data.read_native_u64!(@_mark_offset +! offset)
+
+:: This exposes extra features for `ByteStream.Reader` related to writing bytes
+:: into the buffer, to be read later by readers of the `ByteStream.Reader`.
+::
+:: It is named `ByteStream.Reader.Private` because the "owner" of the stream
+:: will typically want to keep it privately to prevent readers of the stream
+:: from being able to write into it, or otherwise tamper with the buffers.
+::
+:: Some FFI-oriented ways of filling the buffer will rely on the privateness
+:: of this in their strategy for memory safety. For example, Windows IOCP
+:: has a somewhat awkward flow where it takes a pointer to the end of the buffer
+:: and asynchronously writes bytes into it, then tells us how many later.
+:: A flow like this must critically keep would-be tamperers from being able
+:: to invalidate the buffer pointer, or that part of the buffer at all.
+:: So to keep this kind of workflow safe, all methods that could potentially
+:: cause the `ByteStream.Reader` to reallocate its buffer or write into it are
+:: kept in this private view, which can be withheld from would-be tamperers.
+:struct ByteStream.Reader.Private
+  :let public ByteStream.Reader
+
+  :new (space USize = 0x4000)
+    @public = ByteStream.Reader.new(space)
+
+  :: DEPRECATED: Use `new` instead.
+  :new _new_deprecated(@public)
+
+  :: Append the given `bytes` into the underlying buffer.
+  ::
+  :: The bytes will become immediately available for stream readers to read.
+  :fun ref "<<"(bytes Bytes)
+    @public._data << bytes
+    @
+
+  :: Reserve a specific amount of space for writing new bytes into the buffer.
+  ::
+  :: The buffer will not grow (or shrink) if the amount of space available
+  :: for writing already meets or exceeds the given requested amount.
+  ::
+  :: This may result in a copy operation, if the buffer needs to grow and if
+  :: the buffer contains some data not yet extracted away by stream readers.
+  ::
+  :: However, judicious use of this method is the right way to avoid copy
+  :: operations and re-allocations later, by reserving "up front" enough buffer
+  :: to hold the expected amount of incoming data in the next "batch" before
+  :: stream readers will drain the buffer of its content again.
+  :: This is most applicable to framed byte stream protocols wherein it is
+  :: possible to know ahead of time how much buffer will be needed for content.
+  :fun ref reserve_additional(space_for_writing)
+    data = @public._data
+    data.reserve(data.size.saturating_add(space_for_writing))
+    @
+
+  :: Reserve a reasonably-sized buffer for writing directly into from FFI code,
+  :: then return the pointer and the amount of space available for writing.
+  ::
+  :: We guarantee here for the caller's peace of mind that the amount of
+  :: space available for writing will never be zero.
+  ::
+  :: The expected workflow after this method is to write the bytes as needed,
+  :: then call `add_to_size_possibly_including_uninitialized_memory`
+  :: to expose those newly written bytes to readers of the stream.
+  :fun ref prepare_cpointer_for_writing Pair(CPointer(U8), USize)
+    data = @public._data
+
+    if (data.space == data.size) (
+      data.reserve(data.space.saturating_add(0x4000))
+    )
+
+    Pair(CPointer(U8), USize).new(
+      data.cpointer(data.size)
+      data.space - data.size
+    )
+
+  :: Call this method to indicate that some bytes have been written
+  :: into the underlying data buffer via some FFI code.
+  :: The bytes will become exposed to the readers of the stream.
+  ::
+  :: This usually happens after a call to `prepare_cpointer_for_writing`,
+  :: and after that C pointer has been written to via some FFI call.
+  ::
+  :: This is safe in that it will truncate the maximum size to be
+  :: no larger than the space in the currently allocated buffer.
+  :: However, it may expose bytes that haven't been initialized yet,
+  :: if this method is used in a situation where those bytes haven't
+  :: actually been initialized by FFI. In such a situation, you'd see
+  :: undefined byte values, but there would be no memory unsafety.
+  :fun ref add_to_size_possibly_including_uninitialized_memory(
+    added_bytes USize
+  )
+    @public._data.resize_possibly_including_uninitialized_memory(
+      @public._data.size.saturating_add(added_bytes)
+    )
+    @

--- a/src/ByteStream.Sink.savi
+++ b/src/ByteStream.Sink.savi
@@ -33,12 +33,13 @@
 :: considered mostly unimportant.
 :class ByteStream.Sink.ToReader
   :is ByteStream.Sink
-  :is ByteStream.Source
 
-  :let reader ByteStream.Reader
+  :let _reader ByteStream.Reader.Private
   :let _chunks Array(Bytes): []
   :var _total_size USize: 0
-  :new (@reader)
+  :new (@_reader)
+
+  :fun reader: @_reader.public
 
   :fun ref write_bytes(bytes Bytes'val)
     @_chunks << bytes
@@ -46,18 +47,11 @@
     @
 
   :fun ref write_flush!
-    @reader.reserve_additional(@_total_size)
-    @reader.receive_from!(@)
-    @
-
-  :fun ref emit_bytes_into!(buffer Bytes'ref) USize
-    @_chunks.each -> (chunk | buffer << chunk)
-    bytes_read = @_total_size
-
+    @_reader.reserve_additional(@_total_size)
+    @_chunks.each -> (chunk | @_reader << chunk)
     @_chunks.clear
     @_total_size = 0
-
-    bytes_read
+    @
 
 :: This trait is an alternative to `ByteStream.Sink`, used when the sink is
 :: an actor that receives the bytes asynchronously instead of synchronously.

--- a/src/ByteStream.Source.savi
+++ b/src/ByteStream.Source.savi
@@ -1,3 +1,6 @@
+:: DEPRECATED: Implementers of this trait must soon use the methods
+:: exposed by `ByteStream.Reader.Private` instead.
+::
 :: This trait is meant to create a common interface that can be used to get
 :: bytes into a ByteStream.Reader, including compatibility with efficient
 :: patterns that write directly into a buffer from an I/O or network stack.

--- a/src/ByteStream.Writer.savi
+++ b/src/ByteStream.Writer.savi
@@ -7,15 +7,18 @@
 :class ByteStream.Writer
   :is ByteStream.Writable
 
-  :let target ByteStream.Sink
+  :let _target ByteStream.Sink
   :var _current_chunk: Bytes.new_iso
-  :new (@target)
+  :new (@_target)
 
+  :: DEPRECATED: Use `ByteStream.Pair.new` to create a reader and writer pair.
   :new to_reader(reader ByteStream.Reader)
-    @target = ByteStream.Sink.ToReader.new(reader)
+    @_target = ByteStream.Sink.ToReader.new(
+      ByteStream.Reader.Private._new_deprecated(reader)
+    )
 
   :new to_actor(actor ByteStream.Sink.Actor)
-    @target = ByteStream.Sink.ToActor.new(actor)
+    @_target = ByteStream.Sink.ToActor.new(actor)
 
   :: Add a chunk of bytes to the stream.
   ::
@@ -28,7 +31,7 @@
     |
       // Otherwise, we close out the current chunk and then write the new chunk.
       @_finish_current_chunk
-      @target.write_bytes(chunk)
+      @_target.write_bytes(chunk)
     )
     @
 
@@ -60,7 +63,7 @@
   :: from its native byte order to the specified byte order first.
   :fun ref push_native_u64(value): @_current_chunk.push_native_u64(value)
 
-  :: Try to write all data that is currently buffered to the `target` sink.
+  :: Try to write all data that is currently buffered to the target sink.
   ::
   :: Raises an error if there is still some data buffered that could not yet be
   :: flushed, either because the underlying sink was not in a writable state,
@@ -71,11 +74,11 @@
   :: some amount of data still remains in the internal buffer to be transferred.
   :fun ref flush! @
     @_finish_current_chunk
-    @target.write_flush!
+    @_target.write_flush!
     @
 
   :fun ref _finish_current_chunk
-    if @_current_chunk.is_not_empty @target.write_bytes(
+    if @_current_chunk.is_not_empty @_target.write_bytes(
       // Pass along the chunk and allocate a new "current chunk" with the
       // same amount of space as old "current chunk", making the assumption
       // that the typical amount written per chunk will be fairly stable,


### PR DESCRIPTION
These methods will now be segregated into a new
`ByteStream.Reader.Private` struct which can be held privately by whatever data source is writing content into the read stream.

For many data sources, it will not be safe to have these "backend" methods exposed for public usage, so this new approach gives them the opportunity to hold the backend privately, such that they can guarantee no interference and use that guarantee as part of their safety plan for FFI pointer usage.

Many methods were marked as `DEPRECATED` as part of this refactor, and they will be removed later after library users have updated.

See individual `DEPRECATED` annotations for more information about how to refactor downstream code to avoid deprecated use sites.