### PR TITLE
Add `extract_line!` and `extract_frame_u32_be!` to `ByteStream.Reader`.

### DIFF
--- a/spec/ByteStream.Reader.Spec.savi
+++ b/spec/ByteStream.Reader.Spec.savi
@@ -250,6 +250,54 @@
     assert: stream.bytes_behind == 8
     assert: stream.bytes_behind_marker == 8
 
+  :it "extracts a line from the stream (if ready)"
+    streams = ByteStream.Pair.new
+    stream = streams.read
+    write_stream = streams.write
+
+    assert error: stream.extract_line!
+
+    write_stream << b"hel"
+    assert no_error: write_stream.flush!
+    assert error: stream.extract_line!
+
+    write_stream << b"lo\nw"
+    assert no_error: write_stream.flush!
+    assert: stream.extract_line! == b"hello"
+    assert error: stream.extract_line!
+
+    write_stream << b"orld\r"
+    assert no_error: write_stream.flush!
+    assert error: stream.extract_line!
+
+    write_stream << b"\n\n"
+    assert no_error: write_stream.flush!
+    assert: stream.extract_line! == b"world"
+    assert: stream.extract_line! == b""
+    assert error: stream.extract_line!
+
+  :it "extracts a 32-bit-prefixed frame (if ready)"
+    streams = ByteStream.Pair.new
+    stream = streams.read
+    write_stream = streams.write
+
+    assert error: stream.extract_frame_u32_be!
+
+    write_stream << b"\x00\x00\x00"
+    assert no_error: write_stream.flush!
+    assert error: stream.extract_frame_u32_be!
+
+    write_stream << b"\x05hel"
+    assert no_error: write_stream.flush!
+    assert error: stream.extract_frame_u32_be!
+
+    write_stream << b"lo\x00\x00\x00\x05worldextra"
+    assert no_error: write_stream.flush!
+    assert: stream.extract_frame_u32_be! == b"hello"
+    assert: stream.extract_frame_u32_be! == b"world"
+    assert error: stream.extract_frame_u32_be!
+    assert: stream.extract_all == b"extra"
+
   :it "yields each byte of a token"
     streams = ByteStream.Pair.new
     stream = streams.read

--- a/src/ByteStream.Reader.savi
+++ b/src/ByteStream.Reader.savi
@@ -213,6 +213,51 @@
   :fun ref extract_all
     @advance_to_end.extract_token // TODO: more efficient than chop-truncate?
 
+  :: Advance the cursor until the next newline character (`\n`) is found,
+  :: then extract everything from the current marker position forward.
+  ::
+  :: This is useful for line-oriented protocols where each line is a token.
+  ::
+  :: The newline itself and preceding carriage return (`\r`) if present
+  :: will not be included in the extracted bytes.
+  ::
+  :: If no newline is found in the stream, an error will be raised, so that
+  :: the caller can wait for more bytes to be read before trying again.
+  :fun ref extract_line! Bytes'iso
+    // Advance until '\n', raising an error if the stream hasn't seen one yet.
+    @advance_while! -> (byte | byte != '\n')
+    bytes = @extract_token
+
+    // Remove trailing '\r' if present.
+    try (
+      if bytes[bytes.size - 1]! == '\r' ( // TODO: use Bytes.last! after next Savi release
+        bytes.trim_in_place(0, bytes.size - 1)
+      )
+    )
+
+    // Skip '\n' and be ready to read the next line.
+    @advance!(1) // can't error - we know there's a '\n'
+    @mark_here
+
+    --bytes
+
+  :: Extract a byte range from the stream, where the byte range is prefixed by
+  :: an unsigned 32-bit big-endian byte size indicator to frame the protocol.
+  ::
+  :: This is a convenience method for a common network protocol technique.
+  :: If your protocol needs differ, you can easily use this method's
+  :: simple implementation as a basis from which to deviate as needed.
+  ::
+  :: The size prefix itself will not be included in the extracted bytes.
+  ::
+  :: If the stream buffer doesn't have enough bytes yet, an error will be
+  :: raised, so that the caller can wait for more bytes before trying again.
+  :fun ref extract_frame_u32_be! Bytes'iso
+    size = @peek_native_u32!.be_to_native
+    error! if size.usize > @bytes_ahead -! 4
+    @advance!(4), @mark_here
+    @advance!(size.usize), @extract_token
+
   :: Return the portion of the stream between the marker and the cursor,
   :: as an immutable String.
   :fun token_as_string String


### PR DESCRIPTION
These common protocol techniques are worth having convenience methods to simplify common use cases for byte streams.